### PR TITLE
Create 3.7 feature tags script

### DIFF
--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -29,9 +29,11 @@ fi
 
 
 create_bootstrap=false
-if ask_yn "Create bootstrap tags? "; then
-    create_bootstrap=true
-fi
+## Bootstrap tags usually won't be needed for OSG 3.7 features but they
+## might be useful when going from 3.7 to 3.8.
+# if ask_yn "Create bootstrap tags? "; then
+#     create_bootstrap=true
+# fi
 
 
 do_koji () {

--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -4,8 +4,7 @@ set -eu
 # create koji tags/targets/etc for new osg series
 
 SERIES=3.7
-
-build_tag_extras=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
+BUILD_TAG_EXTRAS=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
 
 
 ask_yn () {
@@ -45,42 +44,39 @@ do_koji () {
         koji="echo osg-koji"
     fi
 
-    for EL in el8 el9; do
-        PARENT_PREFIX=osg-$SERIES-main-$EL
-        PREFIX=osg-$SERIES-$FEATURE-$EL
+    local el prefix parent_prefix
+    for el in el8 el9; do
+        parent_prefix="osg-${SERIES}-main-${el}"
+        prefix="osg-${SERIES}-${FEATURE}-${el}"
 
-        ### new tags ###
-
-        $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
-        $koji add-tag --arches=x86_64 $PREFIX-development
-        $koji add-tag --arches=x86_64 $PREFIX-prerelease
-        $koji add-tag --arches=x86_64 $PREFIX-release
-        $koji add-tag --arches=x86_64 $PREFIX-testing
+        ### NEW TAGS
+        #                 OPTIONS                                   TAG
+        $koji add-tag     --arches=x86_64 "${BUILD_TAG_EXTRAS[@]}"  ${prefix}-build
+        $koji add-tag     --arches=x86_64                           ${prefix}-development
+        $koji add-tag     --arches=x86_64                           ${prefix}-prerelease
+        $koji add-tag     --arches=x86_64                           ${prefix}-release
+        $koji edit-tag    --perm=release-team --lock                ${prefix}-release
+        $koji add-tag     --arches=x86_64                           ${prefix}-testing
 
         if $create_bootstrap; then
-            $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+            $koji add-tag --arches=x86_64                           ${prefix}-bootstrap
         fi
 
-        ### tag permissions ###
-
-        $koji edit-tag --perm=release-team --lock $PREFIX-release
-
-        ### tag inheritance ###
-
-
-        $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
+        ### TAG INHERITANCE
+        #                                 PRIORITY  CHILD                    PARENT
+        $koji add-tag-inheritance     --priority=0  ${prefix}-build          ${prefix}-development
+        $koji add-tag-inheritance     --priority=8  ${prefix}-build          ${parent_prefix}-build
+        $koji add-tag-inheritance     --priority=1  ${prefix}-development    ${prefix}-testing
+        $koji add-tag-inheritance     --priority=0  ${prefix}-testing        ${prefix}-release
+        $koji add-tag-inheritance     --priority=0  ${prefix}-release        osg-${el}
         if $create_bootstrap; then
-            $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
+            $koji add-tag-inheritance --priority=4  ${prefix}-build          ${prefix}-bootstrap
         fi
-        $koji add-tag-inheritance --priority=8  $PREFIX-build          $PARENT_PREFIX-build
-        $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
-        $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
-        $koji add-tag-inheritance --priority=0  $PREFIX-release        osg-$EL
 
-        ### build targets ###
-
-        $koji add-target kojira-fake-$PREFIX-development   $PREFIX-development   kojira-fake
-        $koji add-target $PREFIX                           $PREFIX-build         $PREFIX-development
+        ### BUILD TARGETS
+        #                NAME                                FROM                    TO
+        $koji add-target kojira-fake-${prefix}-development   ${prefix}-development   kojira-fake
+        $koji add-target ${prefix}                           ${prefix}-build         ${prefix}-development
 
     done
 }

--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -22,13 +22,11 @@ ask_yn () {
 
 
 
-while [[ ! ${FEATURE-} ]]; do
-    echo -n 'Enter feature name to use for tag (e.g. "xrootd5")> '
-    read -r FEATURE
-    if ! ask_yn "$FEATURE OK? "; then
-        FEATURE=
-    fi
-done
+FEATURE=${1?"Need feature name (e.g. \"xrootd5\")"}
+if [[ ! $FEATURE =~ ^[a-z][a-z0-9]+$ ]]; then
+    echo "Invalid feature name $FEATURE; must start with a letter and have only lowercase letters and numbers"
+    exit 1
+fi
 
 
 create_bootstrap=false

--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -eu
+
+# create koji tags/targets/etc for new osg series
+
+SERIES=3.7
+
+build_tag_extras=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
+
+
+ask_yn () {
+    echo -n "$@"
+    while read -r; do
+        case $REPLY in
+            [Yy]*) return 0 ;;
+            [Nn]*) return 1 ;;
+            *) echo "Enter yes or no" ;;
+        esac
+    done
+    return 2
+}
+
+
+
+while [[ ! ${FEATURE-} ]]; do
+    echo -n 'Enter feature name to use for tag (e.g. "xrootd5")> '
+    read -r FEATURE
+    if ! ask_yn "$FEATURE OK? "; then
+        FEATURE=
+    fi
+done
+
+
+if ask_yn "Dry run? "; then
+    koji="echo osg-koji"
+else
+    koji="osg-koji"
+    set -x
+fi
+
+
+
+for EL in el8 el9; do
+    PARENT_PREFIX=osg-$SERIES-main-$EL
+    PREFIX=osg-$SERIES-$FEATURE-$EL
+
+    ### new tags ###
+
+    $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
+    $koji add-tag --arches=x86_64 $PREFIX-development
+    $koji add-tag --arches=x86_64 $PREFIX-prerelease
+    $koji add-tag --arches=x86_64 $PREFIX-release
+    $koji add-tag --arches=x86_64 $PREFIX-testing
+
+    $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+
+    ### tag permissions ###
+
+    $koji edit-tag --perm=release-team --lock $PREFIX-release
+
+    ### tag inheritance ###
+
+
+    $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
+    $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
+    $koji add-tag-inheritance --priority=8  $PREFIX-build          $PARENT_PREFIX-build
+    $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
+    $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
+    $koji add-tag-inheritance --priority=0  $PREFIX-release        osg-$EL
+
+    ### build targets ###
+
+    $koji add-target kojira-fake-$PREFIX-development   $PREFIX-development   kojira-fake
+    $koji add-target $PREFIX                           $PREFIX-build         $PREFIX-development
+
+done
+
+echo "IF YOU HAVE CREATED NEW BUILD TAGS, BE SURE TO EDIT"
+echo "/etc/koji-hub/plugins/sign.conf AND SET UP PACKAGE SIGNING FOR THE NEW BUILD"
+echo "TAGS."
+

--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -31,6 +31,12 @@ while [[ ! ${FEATURE-} ]]; do
 done
 
 
+create_bootstrap=false
+if ask_yn "Create bootstrap tags? "; then
+    create_bootstrap=true
+fi
+
+
 if ask_yn "Dry run? "; then
     koji="echo osg-koji"
 else
@@ -52,7 +58,9 @@ for EL in el8 el9; do
     $koji add-tag --arches=x86_64 $PREFIX-release
     $koji add-tag --arches=x86_64 $PREFIX-testing
 
-    $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+    if $create_bootstrap; then
+        $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+    fi
 
     ### tag permissions ###
 
@@ -62,7 +70,9 @@ for EL in el8 el9; do
 
 
     $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
-    $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
+    if $create_bootstrap; then
+        $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
+    fi
     $koji add-tag-inheritance --priority=8  $PREFIX-build          $PARENT_PREFIX-build
     $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
     $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
@@ -75,7 +85,7 @@ for EL in el8 el9; do
 
 done
 
-echo "IF YOU HAVE CREATED NEW BUILD TAGS, BE SURE TO EDIT"
-echo "/etc/koji-hub/plugins/sign.conf AND SET UP PACKAGE SIGNING FOR THE NEW BUILD"
-echo "TAGS."
+echo
+echo "DON'T FORGET TO SET UP PACKAGE SIGNING BEFORE USING THE NEW BUILD TAGS"
+echo
 

--- a/koji/osg-3.7/create-3.7-feature-tags-etc
+++ b/koji/osg-3.7/create-3.7-feature-tags-etc
@@ -35,53 +35,63 @@ if ask_yn "Create bootstrap tags? "; then
 fi
 
 
-if ask_yn "Dry run? "; then
-    koji="echo osg-koji"
-else
-    koji="osg-koji"
-    set -x
+do_koji () {
+    local koji
+    local perform_actions="$1"
+    if $perform_actions; then
+        set -x
+        koji="osg-koji"
+    else
+        koji="echo osg-koji"
+    fi
+
+    for EL in el8 el9; do
+        PARENT_PREFIX=osg-$SERIES-main-$EL
+        PREFIX=osg-$SERIES-$FEATURE-$EL
+
+        ### new tags ###
+
+        $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
+        $koji add-tag --arches=x86_64 $PREFIX-development
+        $koji add-tag --arches=x86_64 $PREFIX-prerelease
+        $koji add-tag --arches=x86_64 $PREFIX-release
+        $koji add-tag --arches=x86_64 $PREFIX-testing
+
+        if $create_bootstrap; then
+            $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+        fi
+
+        ### tag permissions ###
+
+        $koji edit-tag --perm=release-team --lock $PREFIX-release
+
+        ### tag inheritance ###
+
+
+        $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
+        if $create_bootstrap; then
+            $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
+        fi
+        $koji add-tag-inheritance --priority=8  $PREFIX-build          $PARENT_PREFIX-build
+        $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
+        $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
+        $koji add-tag-inheritance --priority=0  $PREFIX-release        osg-$EL
+
+        ### build targets ###
+
+        $koji add-target kojira-fake-$PREFIX-development   $PREFIX-development   kojira-fake
+        $koji add-target $PREFIX                           $PREFIX-build         $PREFIX-development
+
+    done
+}
+
+echo "** Doing a dry-run **"
+do_koji false
+echo
+if ask_yn "Do the commands look OK? "; then
+    echo "** Running Koji commands **"
+    do_koji true
 fi
-
-
-
-for EL in el8 el9; do
-    PARENT_PREFIX=osg-$SERIES-main-$EL
-    PREFIX=osg-$SERIES-$FEATURE-$EL
-
-    ### new tags ###
-
-    $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
-    $koji add-tag --arches=x86_64 $PREFIX-development
-    $koji add-tag --arches=x86_64 $PREFIX-prerelease
-    $koji add-tag --arches=x86_64 $PREFIX-release
-    $koji add-tag --arches=x86_64 $PREFIX-testing
-
-    if $create_bootstrap; then
-        $koji add-tag --arches=x86_64 $PREFIX-bootstrap
-    fi
-
-    ### tag permissions ###
-
-    $koji edit-tag --perm=release-team --lock $PREFIX-release
-
-    ### tag inheritance ###
-
-
-    $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
-    if $create_bootstrap; then
-        $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
-    fi
-    $koji add-tag-inheritance --priority=8  $PREFIX-build          $PARENT_PREFIX-build
-    $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
-    $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
-    $koji add-tag-inheritance --priority=0  $PREFIX-release        osg-$EL
-
-    ### build targets ###
-
-    $koji add-target kojira-fake-$PREFIX-development   $PREFIX-development   kojira-fake
-    $koji add-target $PREFIX                           $PREFIX-build         $PREFIX-development
-
-done
 
 echo
 echo "DON'T FORGET TO SET UP PACKAGE SIGNING BEFORE USING THE NEW BUILD TAGS"

--- a/koji/osg-3.7/create-3.7-upcoming-tags-etc
+++ b/koji/osg-3.7/create-3.7-upcoming-tags-etc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec ./create-3.7-feature-tags-etc upcoming


### PR DESCRIPTION
Add `koji/osg-3.7/create-3.7-feature-tags-etc`, which creates a set of "feature" tags and targets for the release series, and sets up tag inheritance. (SOFTWARE-5570)