### PR TITLE
SOFTWARE-5960: OSG 24 koji updates

### DIFF
--- a/koji/osg-24/create-24-empty-contrib-tags-etc
+++ b/koji/osg-24/create-24-empty-contrib-tags-etc
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -eu
+
+# create koji tags/targets/etc for empty and contrib in the new osg series
+
+SERIES=24
+
+build_tag_extras=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
+
+
+ask_yn () {
+    echo -n "$@"
+    while read -r; do
+        case $REPLY in
+            [Yy]*) return 0 ;;
+            [Nn]*) return 1 ;;
+            *) echo "Enter yes or no" ;;
+        esac
+    done
+    return 2
+}
+
+
+if ask_yn "Dry run? "; then
+    koji="echo osg-koji"
+else
+    koji="osg-koji"
+    set -x
+fi
+
+
+for REPO in empty contrib; do
+  for EL in el8 el9; do
+    PREFIX=osg-$SERIES-$EL-$REPO
+
+    ### new tags ###
+
+    $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
+    $koji add-tag --arches=x86_64 $PREFIX
+
+    ### tag inheritance ###
+
+    $koji add-tag-inheritance --priority=2 --noconfig $PREFIX      osg-$EL
+    $koji add-tag-inheritance --priority=1  $PREFIX        dist-$EL
+
+    $koji add-tag-inheritance --priority=1 $PREFIX-build $PREFIX 
+    $koji add-tag-inheritance --priority=2 $PREFIX-build dist-$EL-build
+
+    ### build targets ###
+
+    $koji add-target $PREFIX $PREFIX-build $PREFIX
+
+    ### auto-generated ("minefield-style") repos
+  done
+done
+
+echo "IF YOU HAVE CREATED NEW BUILD TAGS, BE SURE TO EDIT"
+echo "/etc/koji-hub/plugins/sign.conf AND SET UP PACKAGE SIGNING FOR THE NEW BUILD"
+echo "TAGS."
+

--- a/koji/osg-24/create-24-empty-contrib-tags-etc
+++ b/koji/osg-24/create-24-empty-contrib-tags-etc
@@ -35,8 +35,8 @@ for REPO in empty contrib; do
 
     ### new tags ###
 
-    $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
-    $koji add-tag --arches=x86_64 $PREFIX
+    $koji add-tag --arches=x86_64,aarch64 "${build_tag_extras[@]}" $PREFIX-build
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX
 
     ### tag inheritance ###
 

--- a/koji/osg-24/create-24-empty-contrib-tags-etc
+++ b/koji/osg-24/create-24-empty-contrib-tags-etc
@@ -7,6 +7,7 @@ SERIES=24
 
 build_tag_extras=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
 
+AUTO_KEY=34e958b3
 
 ask_yn () {
     echo -n "$@"
@@ -51,6 +52,10 @@ for REPO in empty contrib; do
     $koji add-target $PREFIX $PREFIX-build $PREFIX
 
     ### auto-generated ("minefield-style") repos
+
+    ### Tag2distrepo Config
+    $koji edit-tag -x tag2distrepo.keys=${AUTO_KEY} -x tag2distrepo.enabled=True \
+            -x tag2distrepo.include-outdated=False ${PREFIX}
   done
 done
 

--- a/koji/osg-24/create-24-internal-tags-etc
+++ b/koji/osg-24/create-24-internal-tags-etc
@@ -44,9 +44,9 @@ do_koji () {
 
         ### NEW TAGS
         #                 OPTIONS                                   TAG
-        $koji add-tag     --arches=x86_64 "${BUILD_TAG_EXTRAS[@]}"  ${prefix}-build
-        $koji add-tag     --arches=x86_64                           ${prefix}-development
-        $koji add-tag     --arches=x86_64                           ${prefix}-release
+        $koji add-tag     --arches=x86_64,aarch64 "${BUILD_TAG_EXTRAS[@]}"  ${prefix}-build
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-development
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-release
 
         ### TAG INHERITANCE
         #                                 PRIORITY  CHILD                    PARENT

--- a/koji/osg-24/create-24-internal-tags-etc
+++ b/koji/osg-24/create-24-internal-tags-etc
@@ -6,6 +6,8 @@ set -eu
 SERIES=24
 BUILD_TAG_EXTRAS=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
 
+AUTO_KEY=34e958b3
+DEV_KEY=effc3be6
 
 ask_yn () {
     echo -n "$@"
@@ -64,6 +66,12 @@ do_koji () {
         $koji add-target kojira-fake-${prefix}-development   ${prefix}-development   kojira-fake
         $koji add-target kojira-fake-${prefix}-release       ${prefix}-release       kojira-fake
         # ^^ internal repos do not have a prerelease and the release repo is minefield-style instead of built by mash
+
+        ### Tag2distrepo Config
+        $koji edit-tag -x tag2distrepo.keys=${AUTO_KEY} -x tag2distrepo.enabled=True \
+                -x tag2distrepo.include-outdated=False ${prefix}-development
+        $koji edit-tag -x tag2distrepo.keys=${DEV_KEY} -x tag2distrepo.enabled=True \
+                -x tag2distrepo.include-outdated=True ${prefix}-release
     done
 }
 

--- a/koji/osg-24/create-24-main-tags-etc
+++ b/koji/osg-24/create-24-main-tags-etc
@@ -7,6 +7,8 @@ SERIES=24
 
 build_tag_extras=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
 
+AUTO_KEY=34e958b3
+DEV_KEY=effc3be6
 
 ask_yn () {
     echo -n "$@"
@@ -67,6 +69,14 @@ for EL in el8 el9; do
 
     $koji add-target kojira-fake-$PREFIX-development   $PREFIX-development   kojira-fake
     $koji add-target kojira-fake-$PREFIX-prerelease    $PREFIX-prerelease    kojira-fake
+
+    ### Tag2distrepo Config
+    $koji edit-tag -x tag2distrepo.keys=${AUTO_KEY} -x tag2distrepo.enabled=True \
+            -x tag2distrepo.include-outdated=False ${prefix}-development
+    $koji edit-tag -x tag2distrepo.keys=${DEV_KEY} -x tag2distrepo.enabled=True \
+            -x tag2distrepo.include-outdated=False ${prefix}-testing
+    $koji edit-tag -x tag2distrepo.keys=${DEV_KEY} -x tag2distrepo.enabled=True \
+            -x tag2distrepo.include-outdated=True ${prefix}-release
 
 done
 

--- a/koji/osg-24/create-24-main-tags-etc
+++ b/koji/osg-24/create-24-main-tags-etc
@@ -36,9 +36,7 @@ for EL in el8 el9; do
     ### new tags ###
 
     $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
-    $koji add-tag --arches=x86_64 $PREFIX_NO_MAIN-contrib
     $koji add-tag --arches=x86_64 $PREFIX-development
-    $koji add-tag --arches=x86_64 $PREFIX_NO_MAIN-empty
     $koji add-tag --arches=x86_64 $PREFIX-prerelease
     $koji add-tag --arches=x86_64 $PREFIX-release
     $koji add-tag --arches=x86_64 $PREFIX-testing
@@ -51,17 +49,13 @@ for EL in el8 el9; do
 
     ### tag inheritance ###
 
-    $koji add-tag-inheritance --priority=2 --noconfig $PREFIX_NO_MAIN-contrib      osg-$EL
-    $koji add-tag-inheritance --priority=2 --noconfig $PREFIX_NO_MAIN-empty        osg-$EL
     $koji add-tag-inheritance --priority=1 --noconfig $PREFIX-prerelease   osg-$EL
 
     $koji add-tag-inheritance --priority=0  $PREFIX-build          $PREFIX-development
     $koji add-tag-inheritance --priority=2  $PREFIX-build          osg-$EL-internal
     $koji add-tag-inheritance --priority=4  $PREFIX-build          $PREFIX-bootstrap
     $koji add-tag-inheritance --priority=10 $PREFIX-build          dist-$EL-build
-    $koji add-tag-inheritance --priority=1  $PREFIX_NO_MAIN-contrib        dist-$EL
     $koji add-tag-inheritance --priority=1  $PREFIX-development    $PREFIX-testing
-    $koji add-tag-inheritance --priority=0  $PREFIX_NO_MAIN-empty          dist-$EL
     $koji add-tag-inheritance --priority=0  $PREFIX-release        osg-$EL
     $koji add-tag-inheritance --priority=0  $PREFIX-testing        $PREFIX-release
 

--- a/koji/osg-24/create-24-main-tags-etc
+++ b/koji/osg-24/create-24-main-tags-etc
@@ -35,13 +35,13 @@ for EL in el8 el9; do
 
     ### new tags ###
 
-    $koji add-tag --arches=x86_64 "${build_tag_extras[@]}" $PREFIX-build
-    $koji add-tag --arches=x86_64 $PREFIX-development
-    $koji add-tag --arches=x86_64 $PREFIX-prerelease
-    $koji add-tag --arches=x86_64 $PREFIX-release
-    $koji add-tag --arches=x86_64 $PREFIX-testing
+    $koji add-tag --arches=x86_64,aarch64 "${build_tag_extras[@]}" $PREFIX-build
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX-development
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX-prerelease
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX-release
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX-testing
 
-    $koji add-tag --arches=x86_64 $PREFIX-bootstrap
+    $koji add-tag --arches=x86_64,aarch64 $PREFIX-bootstrap
 
     ### tag permissions ###
 

--- a/koji/osg-24/create-24-upcoming-tags-etc
+++ b/koji/osg-24/create-24-upcoming-tags-etc
@@ -6,6 +6,8 @@ set -eu
 SERIES=24
 BUILD_TAG_EXTRAS=(-x rebuild_srpm=False -x mock.yum.module_hotfixes=1)
 
+AUTO_KEY=34e958b3
+DEV_KEY=effc3be6
 
 ask_yn () {
     echo -n "$@"
@@ -80,6 +82,14 @@ do_koji () {
         #                NAME                                FROM                    TO
         $koji add-target kojira-fake-${prefix}-development   ${prefix}-development   kojira-fake
         $koji add-target kojira-fake-${prefix}-prerelease    ${prefix}-prerelease    kojira-fake
+
+        ### Tag2distrepo Config
+        $koji edit-tag -x tag2distrepo.keys=${AUTO_KEY} -x tag2distrepo.enabled=True \
+                -x tag2distrepo.include-outdated=False ${prefix}-development
+        $koji edit-tag -x tag2distrepo.keys=${DEV_KEY} -x tag2distrepo.enabled=True \
+                -x tag2distrepo.include-outdated=False ${prefix}-testing
+        $koji edit-tag -x tag2distrepo.keys=${DEV_KEY} -x tag2distrepo.enabled=True \
+                -x tag2distrepo.include-outdated=True ${prefix}-release
     done
 }
 

--- a/koji/osg-24/create-24-upcoming-tags-etc
+++ b/koji/osg-24/create-24-upcoming-tags-etc
@@ -50,15 +50,15 @@ do_koji () {
 
         ### NEW TAGS
         #                 OPTIONS                                   TAG
-        $koji add-tag     --arches=x86_64 "${BUILD_TAG_EXTRAS[@]}"  ${prefix}-build
-        $koji add-tag     --arches=x86_64                           ${prefix}-development
-        $koji add-tag     --arches=x86_64                           ${prefix}-prerelease
-        $koji add-tag     --arches=x86_64                           ${prefix}-release
+        $koji add-tag     --arches=x86_64,aarch64 "${BUILD_TAG_EXTRAS[@]}"  ${prefix}-build
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-development
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-prerelease
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-release
         $koji edit-tag    --perm=release-team --lock                ${prefix}-release
-        $koji add-tag     --arches=x86_64                           ${prefix}-testing
+        $koji add-tag     --arches=x86_64,aarch64                           ${prefix}-testing
 
         if $create_bootstrap; then
-            $koji add-tag --arches=x86_64                           ${prefix}-bootstrap
+            $koji add-tag --arches=x86_64,aarch64                           ${prefix}-bootstrap
         fi
 
         ### TAG INHERITANCE


### PR DESCRIPTION
- Add separate script for empty/contrib repos
- Add build targets for empty/contrib repos
- Add aarch64 as a supporter arch